### PR TITLE
Chore/updating docs

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ file. After modifications have been made you can save with
 (defun sops-setup-env ()
   "Set environment variable for SOPS"
   (when (string-match "arn:aws:kms.*:\\([[:digit:]]+\\):" (buffer-string))
-    (pcase (match-string 1 (buffer-string))
+    (pcase (match-string-no-properties 1 (buffer-string))
       ("111111111111" (setenv "AWS_PROFILE" "dev"))
       ("222222222222" (setenv "AWS_PROFILE" "stage"))
       ("333333333333" (setenv "AWS_PROFILE" "prod"))

--- a/sops.el
+++ b/sops.el
@@ -26,7 +26,7 @@
 
 ;;; Commentary:
 
-;; This package allows for easy sops encrypting and decrypting of riles.
+;; This package allows for easy sops encrypting and decrypting of files.
 
 ;;; Code:
 


### PR DESCRIPTION
Found an issue with the `sops-setup-env()` where a sops encrypted file returned a matched string with properties causing a failure to decrypt the encrypted file.