### PR TITLE
Makes buffer read-only when sops-mode is active

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,10 +5,12 @@ To learn more about Secret OPerationS: [[https://github.com/getsops/sops]]
 ** Installation
 
 By enabling ~global-sops-mode~, ~sops-mode~ will try to enable itself
-automatically when we enter a SOPS encrypted file. When you see that
-~sops~ is enabled you can use ~sops-edit-file~ to decrypt the
-file. After modifications have been made you can save with
-~sops-save-file~ or discard modifications with ~sops-cancel~.
+automatically when we enter a SOPS encrypted file. When you see that ~sops~ is
+enabled you can use ~sops-edit-file~ to decrypt the file. After modifications
+have been made you can save with ~sops-save-file~ or discard modifications with
+~sops-cancel~. Sops encrypted files will be shown in ~read-only-mode~ to prevent
+the user from accidentally corrupting an encrypted file. This is useful for
+partly encrypted files, where only a single line might be encrypted.
 
 ~elpaca~ + ~use-package~
 #+begin_example
@@ -41,7 +43,9 @@ file. After modifications have been made you can save with
 
 ** Future
 
-- Add a variable to auto-decrypt when we enter an encrypted file when `global-sops-mode` is enabled.
+- Add a variable to auto-decrypt when we enter an encrypted file when
+  ~global-sops-mode~ is enabled.
 - Create new SOPS encrypted files via ~sops-mode~.
-- If we fail to encrypt (sops < 3.9), we need to revert changes to original-file to encrypted state and switch back to decrypted buffer.
+- If we fail to encrypt (sops < 3.9), we need to revert changes to original-file
+  to encrypted state and switch back to decrypted buffer.
   - We should also show the error buffer too.

--- a/sops.el
+++ b/sops.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Jonathan Carroll Otsuka <pitas.axioms0c@icloud.com>
 ;; Keywords: convenience, programming
-;; Version: 0.1.5
+;; Version: 0.1.6
 ;; Package-Requires: ((emacs "28.1"))
 ;; Homepage: http://github.com/djgoku/sops
 ;; Keywords: convenience files tools sops encrypt decrypt
@@ -70,7 +70,7 @@
                            (setq-local sops-mode nil)
                            (setq-local sops--status nil)))
         ((and (bound-and-true-p sops--status) (equal sops--status "decrypted")) (setq-local sops-mode 1))
-        ((sops--is-sops-file) (setq-local sops-mode 1))
+        ((sops--is-sops-file) (setq-local sops-mode 1) (read-only-mode))
         ((not (sops--is-sops-file)) (progn
                                       (setq-local sops-mode nil)
                                       (setq-local sops--status nil)


### PR DESCRIPTION
- This avoids accidentally corrupting a SOPS encrypted file.