### PR TITLE
Allows saving a file after introducing read-only mode

### DIFF
--- a/sops.el
+++ b/sops.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Jonathan Carroll Otsuka <pitas.axioms0c@icloud.com>
 ;; Keywords: convenience, programming
-;; Version: 0.1.6
+;; Version: 0.1.7
 ;; Package-Requires: ((emacs "28.1"))
 ;; Homepage: http://github.com/djgoku/sops
 ;; Keywords: convenience files tools sops encrypt decrypt
@@ -131,9 +131,11 @@
               (let ((encrypted-buffer-contents (buffer-string))
                     (original-file-name sops--original-buffer-file-name))
                 (switch-to-buffer sops--original-buffer-name)
+                (read-only-mode -1)
                 (erase-buffer)
                 (insert encrypted-buffer-contents)
                 (save-buffer)
+                (read-only-mode)
                 (sops--clean-up-buffers original-file-name))
             (sops--clean-up-buffers (buffer-file-name))))
       (message "no changes were made to file, closing buffer")


### PR DESCRIPTION
I happened to have introduced a bug with pr #11 :slightly_frowning_face: 

SOPS was no longer able to save the file as the buffer was read-only. 
Invoking `sops-save-file` returned `*Messages*` buffer: `funcall-interactively: Buffer is read-only: #<buffer foo.yaml>`.

Manually disabling read-only-mode before invoking `sops-edit-file` made it possible to encrypt the file with `sops-save-file`. 

I've fixed this by disabling `read-only-mode` before the buffer is erased and re-enabling `read-only-mode` when the buffer is saved. This allows for editing and saving a sops encrypted file, while still preventing the user from accidentally editing an encrypted file (hence the need to enable read-only-mode again). 

Sorry for the inconvenience.