### PR TITLE
Revert setting `read-only-mode` for encrypted sops buffers

### DIFF
--- a/sops.el
+++ b/sops.el
@@ -70,7 +70,7 @@
                            (setq-local sops-mode nil)
                            (setq-local sops--status nil)))
         ((and (bound-and-true-p sops--status) (equal sops--status "decrypted")) (setq-local sops-mode 1))
-        ((sops--is-sops-file) (setq-local sops-mode 1) (read-only-mode))
+        ((sops--is-sops-file) (setq-local sops-mode 1))
         ((not (sops--is-sops-file)) (progn
                                       (setq-local sops-mode nil)
                                       (setq-local sops--status nil)


### PR DESCRIPTION
This caused and issues when trying to decrypt and re-encrypt to itself. Going to add some more tests before adding this back in.