### PR TITLE
Add support for specifying additional encrypt args

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,6 +39,7 @@ partly encrypted files, where only a single line might be encrypted.
 |----------------------------------+-----------------------------------------------------------------|
 | sops-executable                  | Path to SOPS executable. Defaults to ~sops~                     |
 | sops-decrypt-args                | SOPS decrypt arguments. Defaults to ~`("-d")~                   |
+| sops-extra-encrypt-args          | SOPS additional encrypt arguments. Defaults to ~`()~            |
 | sops-before-encrypt-decrypt-hook | Run function before encrypting or decrypting. Defaults to ~nil~ |
 
 ** Future

--- a/sops.el
+++ b/sops.el
@@ -43,6 +43,12 @@
   :group 'sops
   :type '(repeat string))
 
+(defcustom sops-extra-encrypt-args
+  `()
+  "Additional encrypt arguments for sops."
+  :group 'sops
+  :type '(repeat string))
+
 (defcustom sops-before-encrypt-decrypt-hook nil
   "Hook run before encrypting or decrypting a sops file."
   :group 'sops
@@ -146,13 +152,13 @@
   "Sops encrypt data."
   (run-hooks 'sops-before-encrypt-decrypt-hook)
   (if sops--sops-version-greater-than-equal-to-3-9
-      (call-process-region (point-min) (point-max) sops-executable t t nil "--filename-override" sops--original-buffer-file-name "--encrypt" "/dev/stdin")
+      (apply 'call-process-region (append (list (point-min) (point-max) sops-executable t t nil "--filename-override" sops--original-buffer-file-name "--encrypt") sops-extra-encrypt-args (list "/dev/stdin")))
     (let ((decrypted-buffer-contents (buffer-string)))
       (switch-to-buffer sops--original-buffer-name)
       (erase-buffer)
       (insert decrypted-buffer-contents)
       (save-buffer)
-      (call-process sops-executable nil nil nil "-e" "-i" (buffer-file-name)))))
+      (apply 'call-process (append (list sops-executable nil nil nil "-e" "-i") sops-extra-encrypt-args (list buffer-file-name))))))
 
 (defun sops-cancel ()
   "Cancel saving sops encrypted data."


### PR DESCRIPTION
I am using SOPS to encrypt files with public SSH keys but right now there was no way to pass the SSH public keys to the sops encrypt command.

The addition of the 'sops-extra-encrypt-args' allows us to provide additional arguments to the `sops encrypt` command and therefore enables support for other modes of encryption (eg. using age for SSH encryption). So, when I do `(setq sops-extra-encrypt-args '("-a" "<sshkey1>,<sshkey2>"))`, it will be possible to encrypt using SSH public keys.
